### PR TITLE
Returns the dragItem to the onDrop function

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -139,7 +139,7 @@ jqyoui.invokeDrop = function($draggable, $droppable, scope, $timeout, event, ui)
         jqyoui.mutateDraggable(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
         jqyoui.mutateDroppable(scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
         if (dropSettings.onDrop) {
-          scope[dropSettings.onDrop](event, ui);
+          scope[dropSettings.onDrop](event, ui, dragItem);
         }
       });
     });
@@ -148,7 +148,7 @@ jqyoui.invokeDrop = function($draggable, $droppable, scope, $timeout, event, ui)
       jqyoui.mutateDraggable(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
       jqyoui.mutateDroppable(scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
       if (dropSettings.onDrop) {
-        scope[dropSettings.onDrop](event, ui);
+        scope[dropSettings.onDrop](event, ui, dragItem);
       }
     });
   }


### PR DESCRIPTION
This change returns the dragItem to the onDrop function. This allows manipulation of the element that is dragged directly.

We've found this really useful when the dropzone is a different element from the list that is going to be augmentated and perhaps it is useful for you too.
