### PR TITLE
Evaluate draggable model in source scope

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -42,7 +42,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
       scope[callbackName].apply(scope, args);
     };
 
-    this.invokeDrop = function ($draggable, $droppable, scope, event, ui) {
+    this.invokeDrop = function ($draggable, $droppable, event, ui) {
       var dragModel = '',
         dropModel = '',
         dragSettings = {},
@@ -52,16 +52,18 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
         dropItem = {},
         dragModelValue,
         dropModelValue,
-        $droppableDraggable = null;
+        $droppableDraggable = null,
+        droppableScope = $droppable.scope(),
+        draggableScope = $draggable.scope();
 
       dragModel = $draggable.attr('ng-model');
       dropModel = $droppable.attr('ng-model');
-      dragModelValue = scope.$eval(dragModel);
-      dropModelValue = scope.$eval(dropModel);
+      dragModelValue = draggableScope.$eval(dragModel);
+      dropModelValue = droppableScope.$eval(dropModel);
 
       $droppableDraggable = $droppable.find('[jqyoui-draggable]:last');
-      dropSettings = scope.$eval($droppable.attr('jqyoui-droppable')) || [];
-      dragSettings = scope.$eval($draggable.attr('jqyoui-draggable')) || [];
+      dropSettings = droppableScope.$eval($droppable.attr('jqyoui-droppable')) || [];
+      dragSettings = draggableScope.$eval($draggable.attr('jqyoui-draggable')) || [];
 
       jqyoui_pos = angular.isArray(dragModelValue) ? dragSettings.index : null;
       dragItem = angular.isArray(dragModelValue) ? dragModelValue[jqyoui_pos] : dragModelValue;
@@ -82,16 +84,16 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
             $draggable.css({'position': 'relative', 'left': '', 'top': ''});
             $droppableDraggable.css({'position': 'relative', 'left': '', 'top': ''});
 
-            this.mutateDraggable(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
-            this.mutateDroppable(scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
-            this.callEventCallback(scope, dropSettings.onDrop, event, ui);
+            this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
+            this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
+            this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
           }.bind(this));
         }.bind(this));
       } else {
         $timeout(function() {
-          this.mutateDraggable(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
-          this.mutateDroppable(scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
-          this.callEventCallback(scope, dropSettings.onDrop, event, ui);
+          this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
+          this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
+          this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
         }.bind(this));
       }
     };
@@ -241,7 +243,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
                   ngDragDropService.callEventCallback(scope, dropSettings.onOut, event, ui);
                 },
                 drop: function(event, ui) {
-                  ngDragDropService.invokeDrop(angular.element(ui.draggable), angular.element(this), scope, event, ui);
+                  ngDragDropService.invokeDrop(angular.element(ui.draggable), angular.element(this), event, ui);
                 }
               });
           } else {

--- a/test/spec/tests.js
+++ b/test/spec/tests.js
@@ -16,9 +16,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2.length).toBe(1);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="list2" jqyoui-droppable="{index: 0}"></div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list2" jqyoui-droppable="{index: 0}"></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -35,9 +34,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2.length).toBe(0);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -54,9 +52,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2.length).toBe(1);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="list2" jqyoui-droppable="{index: 0}"></div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list2" jqyoui-droppable="{index: 0}"></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -72,9 +69,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2.length).toBe(0);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -90,9 +86,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2.length).toBe(1);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="' + scope.list2[0].drag + '" ng-model="list2" jqyoui-droppable="{index: 0}">' + scope.list2[0].title + '</div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="' + scope.list2[0].drag + '" ng-model="list2" jqyoui-droppable="{index: 0}">' + scope.list2[0].title + '</div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -109,9 +104,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.list1.length).toBe(1);
     expect(scope.list2).toEqual({});
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder: \'keep\'}">' + scope.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>'),
-      scope,
+      $('<div data-drag="' + scope.list1[0].drag + '" ng-model="list1" jqyoui-draggable="{index: 0, placeholder: \'keep\'}">' + scope.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list2" jqyoui-droppable></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -129,9 +123,8 @@ describe('Service: ngDragDropService', function() {
     expect(scope.foo.list1.length).toBe(1);
     expect(scope.foo.list2.length).toBe(1);
     ngDragDropService.invokeDrop(
-      $('<div data-drag="' + scope.foo.list1[0].drag + '" ng-model="foo.list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.foo.list1[0].title + '</div>'),
-      $('<div data-drop="true" ng-model="foo.list2" jqyoui-droppable="{index: 0}"></div>'),
-      scope,
+      $('<div data-drag="' + scope.foo.list1[0].drag + '" ng-model="foo.list1" jqyoui-draggable="{index: 0, placeholder:true}">' + scope.foo.list1[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="foo.list2" jqyoui-droppable="{index: 0}"></div>').data('$scope', scope),
       document.createEvent('Event'),
       {}
     );
@@ -140,6 +133,25 @@ describe('Service: ngDragDropService', function() {
     expect(scope.foo.list1[0]).toEqual({});
     expect(scope.foo.list2.length).toBe(1);
     expect(scope.foo.list2[0].title).toBe('Item 1');
+  });
+
+  it('should move item from scope.list[0]:placeholderFalse to scope2.list[0]:dummy', function() {
+    scope.list = [{'title': 'Item 1', 'drag': true}];
+    scope2 = rootScope.$new();
+    scope2.list = [{}];
+    expect(scope.list.length).toBe(1);
+    expect(scope2.list.length).toBe(1);
+
+     ngDragDropService.invokeDrop(
+      $('<div data-drag="' + scope.list[0].drag + '" ng-model="list" jqyoui-draggable="{index: 0}">' + scope.list[0].title + '</div>').data('$scope', scope),
+      $('<div data-drop="true" ng-model="list" jqyoui-droppable="{index: 0}"></div>').data('$scope', scope2),
+      document.createEvent('Event'),
+      {}
+    );
+     timeout.flush();
+     expect(scope.list.length).toBe(0);
+     expect(scope2.list.length).toBe(1);
+     expect(scope2.list[0].title).toBe('Item 1');
   });
 
 });


### PR DESCRIPTION
This allows to move elements between different scopes, e.g. scopes generated by ng-repeat.

Originally all models were evaluated in destination (droppable) scope, which produced incorrect result if draggable model originated from another scope.
