### PR TITLE
Restore z-index on drop stop

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -195,7 +195,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
       require: '?jqyouiDroppable',
       restrict: 'A',
       link: function(scope, element, attrs) {
-        var dragSettings;
+        var dragSettings, zIndex;
         var updateDraggable = function(newValue, oldValue) {
           if (newValue) {
             dragSettings = scope.$eval(element.attr('jqyoui-draggable')) || [];
@@ -204,11 +204,13 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
               .draggable(scope.$eval(attrs.jqyouiOptions) || {})
               .draggable({
                 start: function(event, ui) {
+                  zIndex = $(this).css('z-index');
                   $(this).css('z-index', 99999);
                   jqyoui.startXY = $(this).offset();
                   ngDragDropService.callEventCallback(scope, dragSettings.onStart, event, ui);
                 },
                 stop: function(event, ui) {
+                  $(this).css('z-index', zIndex);
                   ngDragDropService.callEventCallback(scope, dragSettings.onStop, event, ui);
                 },
                 drag: function(event, ui) {


### PR DESCRIPTION
Just a small 'hackish' fix for restoring the z-index property an drag stop.
