### PR TITLE
Add 'reaction' option to jqyoui-droppable

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@
     * **index** – number – $index of an item of a model (if it is an array) associated with it
     * **multiple** – boolean – Requires to be true only if animate is set to true for draggable and to avoid swapping.
     * **stack** – boolean – Requires if animate is set to true on draggable and if multiple draggables positioned one below the other
+    * **reaction** – string – specify behavior of set of draggables when draggable is dropped onto them; possible values: 'swap' (default), 'insert'
     * **onDrop** – string – callback method to be invoked a draggable is dropped into the droppable
     * **onOver** – string – callback method to be invoked when an accepted draggable is dragged over the droppable
     * **onOut** – string – callback method to be invoked when an accepted draggable is dragged out of the droppable

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -140,7 +140,14 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
       if (angular.isArray(dropModelValue)) {
         if (dropSettings && dropSettings.index >= 0) {
-          dropModelValue[dropSettings.index] = dragItem;
+            switch(dropSettings.reaction) {
+            case 'insert': // Insert into model, next items slide over
+                dropModelValue.splice(dropSettings.index, 0, dragItem);
+                break;
+            case 'swap': // Swap places with current item
+            default:
+                dropModelValue[dropSettings.index] = dragItem;
+            }
         } else {
           dropModelValue.push(dragItem);
         }


### PR DESCRIPTION
When you drop a draggable onto a collection of draggables, current behavior is to swap places with item you drop onto. I've added a second behavior, to have items slide over and let dropped item insert. These 'reaction' options are 'swap' (default) and 'insert'.
