### PR TITLE
Do not reset css position when using helper: clone

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -158,6 +158,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
     this.mutateDraggable = function(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable) {
       var isEmpty = $.isEmptyObject(angular.copy(dropItem)),
         dragModelValue = scope.$eval(dragModel);
+      var dragOptions = scope.$eval($draggable.attr('data-jqyoui-options')) || {};
 
       scope.__dropItem = dropItem;
 
@@ -187,8 +188,10 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
           }
         }
       }
+      if (dragOptions.helper !== 'clone') {
+        $draggable.css({'z-index': '', 'left': '', 'top': ''});
+      }
 
-      $draggable.css({'z-index': '', 'left': '', 'top': ''});
     };
   }]).directive('jqyouiDraggable', ['ngDragDropService', function(ngDragDropService) {
     return {


### PR DESCRIPTION
This is actually a work-around for issue with CSS left, top being cleared on drag stop. This is a problem if the draggable has absolute positioning and placeholder: 'keep' is used -- the draggable disappears on drag stop. In my situation I was using helper: clone anyway, so this patch just leaves the draggable's CSS positioning alone since it never changed in the first place.

This also restores the z-index fix of a few commits ago -- the recent refactoring broke that z-index fix. The problem is that mutateDraggable is called within a $timeout() delay, so the z-index fix restores the original z-index, and then the delayed mutateDraggable just blows it away again.
