### PR TITLE
Changing use of >= IE9 dependent array map method to use jQuery map meth...

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -51,7 +51,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
         return {
           callback: callbackName.substring(constructor && constructor.length + 1 || 0, atStartBracket),
-          args: (args && args.split(',') || []).map(function(item) { return $parse(item)(scope); }),
+          args: $.map((args && args.split(',') || []), function(item) { return $parse(item)(scope); }),
           constructor: constructor
         }
       }


### PR DESCRIPTION
...od for IE8 support since jQuery is already a dependency.

Hi all, since map is a method native to browsers >= IE9 and jQuery is already a dependency on this project, I thought it was useful to use the jQuery map method instead so IE8 can take advantage of this library in Angular 1.2 and below.
