### PR TITLE
sortable as a new attribute - fixed animations and added README.md.

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Do not pass evaluated expressions in callbacks. For example,
     * **onStart** – string – callback method to be invoked (has to be defined in a controller) when dragging starts
     * **onStop** – string – callback method to be invoked when dragging stops
     * **onDrag** – string – callback method to be invoked while the mouse is moved during the dragging
+    * **sortable** – boolean – If true, the dropped item will be inserted after the droppable and the rest of the items will rotate upwards towards the droppable. This will only work when the draggable and droppable use the same model.
     * **applyFilter** - string - applies AngularJS $filter on the list before swapping items. Only applicable, if ngRepeat has any filter (such as orderBy, limitTo) associated with it.
     * **containment** – string - position/offset. Offset by default. This forces to use jQuery.position() or jQuery.offset() to calculate proper position with respect to parent element or document respectively. 
 * **data-drag** – boolean – If true, element can be draggable. Disabled otherwise.

--- a/demo/dnd-ctrl-as-syntax.html
+++ b/demo/dnd-ctrl-as-syntax.html
@@ -70,7 +70,7 @@
         <div class='content'>
           <div class="row-fluid">
             <ul class="thumbnails">
-              <li ng-repeat="item in list1" data-drop="true" ng-model='list1' jqyoui-droppable="{index: {{$index}}, onDrop:'loki.dropCallback(item.title, $index)'}">
+              <li ng-repeat="item in list1" data-drop="true"  ng-model='list1' jqyoui-droppable="{index: {{$index}}, onDrop:'loki.dropCallback(item.title, $index)'}">
                 <div class="thumbnail" data-drag="{{item.drag}}" data-jqyoui-options="{revert: 'invalid'}" ng-model="list1" jqyoui-draggable="{index: {{$index}},animate:true}">
                   <h1>
                     {{item.title}}

--- a/demo/dnd-ctrls-sortable.html
+++ b/demo/dnd-ctrls-sortable.html
@@ -1,0 +1,89 @@
+<!DOCTYPE html>
+<html ng-app="drag-and-drop">
+<head lang="en">
+    <meta charset="utf-8">
+    <title>Drag &amp; Drop: Guess A Name</title>
+    <!-- <script src="http://ajax.googleapis.com/ajax/libs/jquery/1/jquery.min.js"></script>
+    <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"></script>
+    <script src="https://ajax.googleapis.com/ajax/libs/angularjs/1.2.0/angular.min.js"></script>
+    <link href="http://ajax.googleapis.com/ajax/libs/jqueryui/1/themes/base/jquery-ui.css" rel="stylesheet" type="text/css" />
+    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap.min.css" rel="stylesheet"> -->
+    <script src="../components/jquery/dist/jquery.min.js"></script>
+    <script src="../components/jquery-ui/jquery-ui.min.js"></script>
+    <script src="../components/angular/angular.min.js"></script>
+    <script src="../src/angular-dragdrop.js"></script>
+    <link href="assets/css/bootstrap.min.css" rel="stylesheet">
+    <style>
+        body {
+            padding: 30px;
+        }
+        .thumbnail {
+            height: 50px;
+            width: 50px;
+            text-align: center;
+            padding-top: 0px;
+            transition: none;
+            -webkit-transition: none;
+            -moz-transition: none;
+            -o-transition: none;
+            cursor: pointer;
+            background: rgb(182, 173, 123);
+        }
+
+        .thumbnail[data-drag="false"] { background: green; }
+
+        li {
+            height: 56px;
+            width: 60px;
+            line-height: 20px;
+            border: 1px solid #ddd;
+            padding: 3px;
+            margin-left: 10px;
+        }
+    </style>
+
+    <script type="text/javascript">
+        var App = angular.module('drag-and-drop', ['ngDragDrop']);
+
+        App.controller('oneCtrl', function($scope) {
+            $scope.list1 = [
+                { 'title': '0', 'drag': true },
+                { 'title': '1', 'drag': true },
+                { 'title': '2', 'drag': true },
+                { 'title': '3', 'drag': true },
+                { 'title': '4', 'drag': true },
+                { 'title': '5', 'drag': true },
+                { 'title': '6', 'drag': true },
+                { 'title': '7', 'drag': true },
+                { 'title': '8', 'drag': true }
+            ];
+
+            this.dropCallback = function(event, ui, title, $index) {
+                if ($scope.list1.map(function(item) { return item.title; }).join('') === 'GOLLUM') {
+                    $scope.list1.forEach(function(value, key) { $scope.list1[key].drag = false; });
+                }
+            };
+        });
+    </script>
+</head>
+<body>
+<h2>Whose dialog is it? <em>"What is it, Precious? What is it?"</em></h2>
+<div ng-controller="oneCtrl as numbers">
+    <div class='contentWrapper ng-cloak'>
+        <div class='content'>
+            <div class="row-fluid">
+                <ul class="thumbnails">
+                    <li ng-repeat="item in list1"  data-drop="true" ng-model='list1' jqyoui-droppable="{index: {{$index}}, onDrop:'numbers.dropCallback(item.title, $index)'}">
+                        <div class="thumbnail" data-drag="{{item.drag}}" data-jqyoui-options="{revert: 'invalid'}" ng-model="list1" jqyoui-draggable="{index: {{$index}},animate:true,sortable:true}">
+                            <h1>
+                                {{item.title}}
+                            </h1>
+                        </div>
+                    </li>
+                </ul>
+            </div>
+        </div>
+    </div>
+</div>
+</body>
+</html>

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -28,302 +28,346 @@
  */
 
 (function (window, angular, undefined) {
-'use strict';
+    'use strict';
 
-var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$timeout', '$parse', function($timeout, $parse) {
-    this.callEventCallback = function (scope, callbackName, event, ui) {
-      if (!callbackName) return;
+    var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$timeout', '$parse', function ($timeout, $parse) {
+        this.callEventCallback = function (scope, callbackName, event, ui) {
+            if (!callbackName) return;
 
-      var objExtract = extract(callbackName),
-          callback = objExtract.callback,
-          constructor = objExtract.constructor,
-          args = [event, ui].concat(objExtract.args);
-      
-      // call either $scoped method i.e. $scope.dropCallback or constructor's method i.e. this.dropCallback
-      scope.$apply((scope[callback] || scope[constructor][callback]).apply(scope, args));
-      
-      function extract(callbackName) {
-        var atStartBracket = callbackName.indexOf('(') !== -1 ? callbackName.indexOf('(') : callbackName.length,
-            atEndBracket = callbackName.lastIndexOf(')') !== -1 ? callbackName.lastIndexOf(')') : callbackName.length,
-            args = callbackName.substring(atStartBracket + 1, atEndBracket), // matching function arguments inside brackets
-            constructor = callbackName.match(/^[^.]+.\s*/)[0].slice(0, -1); // matching a string upto a dot to check ctrl as syntax
-            constructor = scope[constructor] && typeof scope[constructor].constructor === 'function' ? constructor : null;
+            var objExtract = extract(callbackName),
+                callback = objExtract.callback,
+                constructor = objExtract.constructor,
+                args = [event, ui].concat(objExtract.args);
 
-        return {
-          callback: callbackName.substring(constructor && constructor.length + 1 || 0, atStartBracket),
-          args: (args && args.split(',') || []).map(function(item) { return $parse(item)(scope); }),
-          constructor: constructor
-        }
-      }
-    };
+            // call either $scoped method i.e. $scope.dropCallback or constructor's method i.e. this.dropCallback
+            scope.$apply((scope[callback] || scope[constructor][callback]).apply(scope, args));
 
-    this.invokeDrop = function ($draggable, $droppable, event, ui) {
-      var dragModel = '',
-        dropModel = '',
-        dragSettings = {},
-        dropSettings = {},
-        jqyoui_pos = null,
-        dragItem = {},
-        dropItem = {},
-        dragModelValue,
-        dropModelValue,
-        $droppableDraggable = null,
-        droppableScope = $droppable.scope(),
-        draggableScope = $draggable.scope();
+            function extract(callbackName) {
+                var atStartBracket = callbackName.indexOf('(') !== -1 ? callbackName.indexOf('(') : callbackName.length,
+                    atEndBracket = callbackName.lastIndexOf(')') !== -1 ? callbackName.lastIndexOf(')') : callbackName.length,
+                    args = callbackName.substring(atStartBracket + 1, atEndBracket), // matching function arguments inside brackets
+                    constructor = callbackName.match(/^[^.]+.\s*/)[0].slice(0, -1); // matching a string upto a dot to check ctrl as syntax
+                constructor = scope[constructor] && typeof scope[constructor].constructor === 'function' ? constructor : null;
 
-      dragModel = $draggable.ngattr('ng-model');
-      dropModel = $droppable.ngattr('ng-model');
-      dragModelValue = draggableScope.$eval(dragModel);
-      dropModelValue = droppableScope.$eval(dropModel);
-
-      $droppableDraggable = $droppable.find('[jqyoui-draggable]:last,[data-jqyoui-draggable]:last');
-      dropSettings = droppableScope.$eval($droppable.attr('jqyoui-droppable') || $droppable.attr('data-jqyoui-droppable')) || [];
-      dragSettings = draggableScope.$eval($draggable.attr('jqyoui-draggable') || $draggable.attr('data-jqyoui-draggable')) || [];
-
-      // Helps pick up the right item
-      dragSettings.index = this.fixIndex(draggableScope, dragSettings, dragModelValue);
-      dropSettings.index = this.fixIndex(droppableScope, dropSettings, dropModelValue);
-
-      jqyoui_pos = angular.isArray(dragModelValue) ? dragSettings.index : null;
-      dragItem = angular.copy(angular.isArray(dragModelValue) ? dragModelValue[jqyoui_pos] : dragModelValue);
-
-      if (angular.isArray(dropModelValue) && dropSettings && dropSettings.index !== undefined) {
-        dropItem = dropModelValue[dropSettings.index];
-      } else if (!angular.isArray(dropModelValue)) {
-        dropItem = dropModelValue;
-      } else {
-        dropItem = {};
-      }
-      dropItem = angular.copy(dropItem);
-
-      if (dragSettings.animate === true) {
-        this.move($draggable, $droppableDraggable.length > 0 ? $droppableDraggable : $droppable, null, 'fast', dropSettings, null);
-        this.move($droppableDraggable.length > 0 && !dropSettings.multiple ? $droppableDraggable : [], $draggable.parent('[jqyoui-droppable],[data-jqyoui-droppable]'), jqyoui.startXY, 'fast', dropSettings, angular.bind(this, function() {
-          $timeout(angular.bind(this, function() {
-            // Do not move this into move() to avoid flickering issue
-            $draggable.css({'position': 'relative', 'left': '', 'top': ''});
-            // Angular v1.2 uses ng-hide to hide an element not display property
-            // so we've to manually remove display:none set in this.move()
-            $droppableDraggable.css({'position': 'relative', 'left': '', 'top': '', 'display': ''});
-
-            this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
-            this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
-            this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
-          }));
-        }));
-      } else {
-        $timeout(angular.bind(this, function() {
-          this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
-          this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
-          this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
-        }));
-      }
-    };
-
-    this.move = function($fromEl, $toEl, toPos, duration, dropSettings, callback) {
-      if ($fromEl.length === 0) {
-        if (callback) {
-          window.setTimeout(function() {
-            callback();
-          }, 300);
-        }
-        return false;
-      }
-
-      var zIndex = 9999,
-        fromPos = $fromEl[dropSettings.containment || 'offset'](),
-        wasVisible = $toEl && $toEl.is(':visible'),
-        hadNgHideCls = $toEl.hasClass('ng-hide');
-
-      if (toPos === null && $toEl.length > 0) {
-        if (($toEl.attr('jqyoui-draggable') || $toEl.attr('data-jqyoui-draggable')) !== undefined && $toEl.ngattr('ng-model') !== undefined && $toEl.is(':visible') && dropSettings && dropSettings.multiple) {
-          toPos = $toEl[dropSettings.containment || 'offset']();
-          if (dropSettings.stack === false) {
-            toPos.left+= $toEl.outerWidth(true);
-          } else {
-            toPos.top+= $toEl.outerHeight(true);
-          }
-        } else {
-          // Angular v1.2 uses ng-hide to hide an element 
-          // so we've to remove it in order to grab its position
-          if (hadNgHideCls) $toEl.removeClass('ng-hide');
-          toPos = $toEl.css({'visibility': 'hidden', 'display': 'block'})[dropSettings.containment || 'offset']();
-          $toEl.css({'visibility': '','display': wasVisible ? 'block' : 'none'});
-        }
-      }
-
-      $fromEl.css({'position': 'absolute', 'z-index': zIndex})
-        .css(fromPos)
-        .animate(toPos, duration, function() {
-          // Angular v1.2 uses ng-hide to hide an element
-          // and as we remove it above, we've to put it back to
-          // hide the element (while swapping) if it was hidden already
-          // because we remove the display:none in this.invokeDrop()
-          if (hadNgHideCls) $toEl.addClass('ng-hide');
-          if (callback) callback();
-        });
-    };
-
-    this.mutateDroppable = function(scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos) {
-      var dropModelValue = scope.$eval(dropModel);
-
-      scope.dndDragItem = dragItem;
-
-      if (angular.isArray(dropModelValue)) {
-        if (dropSettings && dropSettings.index >= 0) {
-          dropModelValue[dropSettings.index] = dragItem;
-        } else {
-          dropModelValue.push(dragItem);
-        }
-        if (dragSettings && dragSettings.placeholder === true) {
-          dropModelValue[dropModelValue.length - 1]['jqyoui_pos'] = jqyoui_pos;
-        }
-      } else {
-        $parse(dropModel + ' = dndDragItem')(scope);
-        if (dragSettings && dragSettings.placeholder === true) {
-          dropModelValue['jqyoui_pos'] = jqyoui_pos;
-        }
-      }
-    };
-
-    this.mutateDraggable = function(scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable) {
-      var isEmpty = angular.equals(dropItem, {}),
-        dragModelValue = scope.$eval(dragModel);
-
-      scope.dndDropItem = dropItem;
-
-      if (dragSettings && dragSettings.placeholder) {
-        if (dragSettings.placeholder != 'keep'){
-          if (angular.isArray(dragModelValue) && dragSettings.index !== undefined) {
-            dragModelValue[dragSettings.index] = dropItem;
-          } else {
-            $parse(dragModel + ' = dndDropItem')(scope);
-          }
-        }
-      } else {
-        if (angular.isArray(dragModelValue)) {
-          if (isEmpty) {
-            if (dragSettings && ( dragSettings.placeholder !== true && dragSettings.placeholder !== 'keep' )) {
-              dragModelValue.splice(dragSettings.index, 1);
+                return {
+                    callback: callbackName.substring(constructor && constructor.length + 1 || 0, atStartBracket),
+                    args: (args && args.split(',') || []).map(function (item) {
+                        return $parse(item)(scope);
+                    }),
+                    constructor: constructor
+                }
             }
-          } else {
-            dragModelValue[dragSettings.index] = dropItem;
-          }
-        } else {
-          // Fix: LIST(object) to LIST(array) - model does not get updated using just scope[dragModel] = {...}
-          // P.S.: Could not figure out why it happened
-          $parse(dragModel + ' = dndDropItem')(scope);
-          if (scope.$parent) {
-            $parse(dragModel + ' = dndDropItem')(scope.$parent);
-          }
-        }
-      }
-
-      $draggable.css({'z-index': '', 'left': '', 'top': ''});
-    };
-
-    this.fixIndex = function(scope, settings, modelValue) {
-      if (settings.applyFilter && angular.isArray(modelValue) && modelValue.length > 0) {
-        var dragModelValueFiltered = scope[settings.applyFilter](),
-            lookup = dragModelValueFiltered[settings.index],
-            actualIndex = undefined;
-
-        modelValue.forEach(function(item, i) {
-           if (angular.equals(item, lookup)) {
-             actualIndex = i;
-           }
-        });
-
-        return actualIndex;
-      }
-
-      return settings.index;
-    };
-  }]).directive('jqyouiDraggable', ['ngDragDropService', function(ngDragDropService) {
-    return {
-      require: '?jqyouiDroppable',
-      restrict: 'A',
-      link: function(scope, element, attrs) {
-        var dragSettings, jqyouiOptions, zIndex;
-        var updateDraggable = function(newValue, oldValue) {
-          if (newValue) {
-            dragSettings = scope.$eval(element.attr('jqyoui-draggable') || element.attr('data-jqyoui-draggable')) || {};
-            jqyouiOptions = scope.$eval(attrs.jqyouiOptions) || {};
-            element
-              .draggable({disabled: false})
-              .draggable(jqyouiOptions)
-              .draggable({
-                start: function(event, ui) {
-                  zIndex = angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index');
-                  angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index', 9999);
-                  jqyoui.startXY = angular.element(this)[dragSettings.containment || 'offset']();
-                  ngDragDropService.callEventCallback(scope, dragSettings.onStart, event, ui);
-                },
-                stop: function(event, ui) {
-                  angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index', zIndex);
-                  ngDragDropService.callEventCallback(scope, dragSettings.onStop, event, ui);
-                },
-                drag: function(event, ui) {
-                  ngDragDropService.callEventCallback(scope, dragSettings.onDrag, event, ui);
-                }
-              });
-          } else {
-            element.draggable({disabled: true});
-          }
-        };
-        scope.$watch(function() { return scope.$eval(attrs.drag); }, updateDraggable);
-        updateDraggable();
-
-        element.on('$destroy', function() {
-          element.draggable('destroy');
-        });
-      }
-    };
-  }]).directive('jqyouiDroppable', ['ngDragDropService', function(ngDragDropService) {
-    return {
-      restrict: 'A',
-      priority: 1,
-      link: function(scope, element, attrs) {
-        var dropSettings;
-        var updateDroppable = function(newValue, oldValue) {
-          if (newValue) {
-            dropSettings = scope.$eval(angular.element(element).attr('jqyoui-droppable') || angular.element(element).attr('data-jqyoui-droppable')) || {};
-            element
-              .droppable({disabled: false})
-              .droppable(scope.$eval(attrs.jqyouiOptions) || {})
-              .droppable({
-                over: function(event, ui) {
-                  ngDragDropService.callEventCallback(scope, dropSettings.onOver, event, ui);
-                },
-                out: function(event, ui) {
-                  ngDragDropService.callEventCallback(scope, dropSettings.onOut, event, ui);
-                },
-                drop: function(event, ui) {
-                  if (angular.element(ui.draggable).ngattr('ng-model') && attrs.ngModel) {
-                    ngDragDropService.invokeDrop(angular.element(ui.draggable), angular.element(this), event, ui);
-                  } else {
-                    ngDragDropService.callEventCallback(scope, dropSettings.onDrop, event, ui);
-                  }
-                }
-              });
-          } else {
-            element.droppable({disabled: true});
-          }
         };
 
-        scope.$watch(function() { return scope.$eval(attrs.drop); }, updateDroppable);
-        updateDroppable();
+        this.invokeDrop = function ($draggable, $droppable, event, ui) {
+            var dragModel = '',
+                dropModel = '',
+                dragSettings = {},
+                dropSettings = {},
+                jqyoui_pos = null,
+                dragItem = {},
+                dropItem = {},
+                dragModelValue,
+                dropModelValue,
+                $droppableDraggable = null,
+                droppableScope = $droppable.scope(),
+                draggableScope = $draggable.scope();
+            dragModel = $draggable.ngattr('ng-model');
+            dropModel = $droppable.ngattr('ng-model');
+            dragModelValue = draggableScope.$eval(dragModel);
+            dropModelValue = droppableScope.$eval(dropModel);
 
-        element.on('$destroy', function() {
-          element.droppable('destroy');
-        });
-      }
+            $droppableDraggable = $droppable.find('[jqyoui-draggable]:last,[data-jqyoui-draggable]:last');
+            dropSettings = droppableScope.$eval($droppable.attr('jqyoui-droppable') || $droppable.attr('data-jqyoui-droppable')) || [];
+            dragSettings = draggableScope.$eval($draggable.attr('jqyoui-draggable') || $draggable.attr('data-jqyoui-draggable')) || [];
+
+            // Helps pick up the right item
+            dragSettings.index = this.fixIndex(draggableScope, dragSettings, dragModelValue);
+            dropSettings.index = this.fixIndex(droppableScope, dropSettings, dropModelValue);
+
+            jqyoui_pos = angular.isArray(dragModelValue) ? dragSettings.index : null;
+            dragItem = angular.copy(angular.isArray(dragModelValue) ? dragModelValue[jqyoui_pos] : dragModelValue);
+
+            var resetCSS = angular.bind(this, function () {
+                $timeout(angular.bind(this, function () {
+                    // Do not move this into move() to avoid flickering issue
+                    $draggable.css({'position': 'relative', 'left': '', 'top': ''});
+                    // Angular v1.2 uses ng-hide to hide an element not display property
+                    // so we've to manually remove display:none set in this.move()
+                    $droppableDraggable.css({'position': 'relative', 'left': '', 'top': '', 'display': ''});
+
+                    this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
+                    this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
+                    this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
+                }));
+            });
+            if (angular.isArray(dropModelValue) && dropSettings && dropSettings.index !== undefined) {
+                dropItem = dropModelValue[dropSettings.index];
+            } else if (!angular.isArray(dropModelValue)) {
+                dropItem = dropModelValue;
+            } else {
+                dropItem = {};
+            }
+            dropItem = angular.copy(dropItem);
+
+
+            if (dragSettings.animate === true) {
+                var allDraggables = $('.ui-draggable').toArray();
+                if (dragSettings.sortable) {
+                    //Left slide
+                    if (dropSettings.index > dragSettings.index) {
+                        this.move($draggable, $droppableDraggable.length > 0 ? $droppableDraggable : $droppable, null, 'fast', dropSettings, null);
+                        for (var i = dropSettings.index ; i > dragSettings.index; i--) {
+                            if(i === dragSettings.index + 1){
+                               this.move(angular.element(allDraggables[i]), $draggable.parent('[jqyoui-droppable],[data-jqyoui-droppable]'), jqyoui.startXY,'fast', dropSettings, resetCSS);
+                            }else{
+                                this.move(angular.element(allDraggables[i]), angular.element(allDraggables[i - 1]), null, 'fast', dropSettings, null);
+                            }
+                        }
+                    } else {
+                        //Right slide
+                        this.move($draggable, $droppableDraggable.length > 0 ? $droppableDraggable : $droppable, null, 'fast', dropSettings, null);
+                        for (var i = dropSettings.index ; i < dragSettings.index; i++) {
+                            if(i === dragSettings.index - 1){
+                                this.move(angular.element(allDraggables[i]), $draggable.parent('[jqyoui-droppable],[data-jqyoui-droppable]'), jqyoui.startXY,'fast', dropSettings, resetCSS);
+                            }else{
+                                this.move(angular.element(allDraggables[i]), angular.element(allDraggables[i + 1]), null, 'fast', dropSettings, null);
+                            }
+                        }
+                    }
+                } else {
+                    this.move($draggable, $droppableDraggable.length > 0 ? $droppableDraggable : $droppable, null, 'fast', dropSettings, null);
+                    this.move($droppableDraggable.length > 0 && !dropSettings.multiple ? $droppableDraggable : [], $draggable.parent('[jqyoui-droppable],[data-jqyoui-droppable]'), jqyoui.startXY, 'fast', dropSettings, resetCSS);
+                }
+
+            } else {
+                $timeout(angular.bind(this, function () {
+                    this.mutateDraggable(draggableScope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable);
+                    this.mutateDroppable(droppableScope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos);
+                    this.callEventCallback(droppableScope, dropSettings.onDrop, event, ui);
+                }));
+            }
+        };
+
+        this.move = function ($fromEl, $toEl, toPos, duration, dropSettings, callback) {
+            if ($fromEl.length === 0) {
+                if (callback) {
+                    window.setTimeout(function () {
+                        callback();
+                    }, 300);
+                }
+                return false;
+            }
+
+            var zIndex = 9999,
+                fromPos = $fromEl[dropSettings.containment || 'offset'](),
+                wasVisible = $toEl && $toEl.is(':visible'),
+                hadNgHideCls = $toEl.hasClass('ng-hide');
+
+            if (toPos === null && $toEl.length > 0) {
+                if (($toEl.attr('jqyoui-draggable') || $toEl.attr('data-jqyoui-draggable')) !== undefined && $toEl.ngattr('ng-model') !== undefined && $toEl.is(':visible') && dropSettings && dropSettings.multiple) {
+                    toPos = $toEl[dropSettings.containment || 'offset']();
+                    if (dropSettings.stack === false) {
+                        toPos.left += $toEl.outerWidth(true);
+                    } else {
+                        toPos.top += $toEl.outerHeight(true);
+                    }
+                } else {
+                    // Angular v1.2 uses ng-hide to hide an element
+                    // so we've to remove it in order to grab its position
+                    if (hadNgHideCls) $toEl.removeClass('ng-hide');
+                    toPos = $toEl.css({
+                        'visibility': 'hidden',
+                        'display': 'block'
+                    })[dropSettings.containment || 'offset']();
+                    $toEl.css({'visibility': '', 'display': wasVisible ? 'block' : 'none'});
+                }
+            }
+           // console.log(console.dir(fromPos) + ' ' + console.dir(toPos));
+            $fromEl.css({'position': 'absolute', 'z-index': zIndex})
+                .css(fromPos)
+                .animate(toPos, duration, function () {
+                    // Angular v1.2 uses ng-hide to hide an element
+                    // and as we remove it above, we've to put it back to
+                    // hide the element (while swapping) if it was hidden already
+                    // because we remove the display:none in this.invokeDrop()
+                    if (hadNgHideCls) $toEl.addClass('ng-hide');
+                    if (callback) callback();
+                });
+        };
+
+        this.mutateDroppable = function (scope, dropSettings, dragSettings, dropModel, dragItem, jqyoui_pos) {
+            var dropModelValue = scope.$eval(dropModel);
+
+            scope.dndDragItem = dragItem;
+
+            if (angular.isArray(dropModelValue)) {
+                if (dropSettings && dropSettings.index >= 0) {
+                    if (dragSettings.sortable) {
+                        dropModelValue.splice(dropSettings.index, 0, dragItem);
+                    } else {
+                        dropModelValue[dropSettings.index] = dragItem;
+                    }
+                } else {
+                    dropModelValue.push(dragItem);
+                }
+                if (dragSettings && dragSettings.placeholder === true) {
+                    dropModelValue[dropModelValue.length - 1]['jqyoui_pos'] = jqyoui_pos;
+                }
+            } else {
+                $parse(dropModel + ' = dndDragItem')(scope);
+                if (dragSettings && dragSettings.placeholder === true) {
+                    dropModelValue['jqyoui_pos'] = jqyoui_pos;
+                }
+            }
+        };
+
+        this.mutateDraggable = function (scope, dropSettings, dragSettings, dragModel, dropModel, dropItem, $draggable) {
+            var isEmpty = angular.equals(dropItem, {}),
+                dragModelValue = scope.$eval(dragModel);
+
+            scope.dndDropItem = dropItem;
+
+            if (dragSettings && dragSettings.placeholder) {
+                if (dragSettings.placeholder != 'keep') {
+                    if (angular.isArray(dragModelValue) && dragSettings.index !== undefined) {
+                        dragModelValue[dragSettings.index] = dropItem;
+                    } else {
+                        $parse(dragModel + ' = dndDropItem')(scope);
+                    }
+                }
+            } else {
+                if (angular.isArray(dragModelValue)) {
+                    if (isEmpty) {
+                        if (dragSettings && ( dragSettings.placeholder !== true && dragSettings.placeholder !== 'keep' )) {
+                            dragModelValue.splice(dragSettings.index, 1);
+                        }
+                    } else {
+                        if (dragSettings.sortable) {
+                            dragModelValue.splice(dragSettings.index, 1);
+                        } else {
+                            dragModelValue[dragSettings.index] = dropItem;
+                        }
+                    }
+                } else {
+                    // Fix: LIST(object) to LIST(array) - model does not get updated using just scope[dragModel] = {...}
+                    // P.S.: Could not figure out why it happened
+                    $parse(dragModel + ' = dndDropItem')(scope);
+                    if (scope.$parent) {
+                        $parse(dragModel + ' = dndDropItem')(scope.$parent);
+                    }
+                }
+            }
+
+            $draggable.css({'z-index': '', 'left': '', 'top': ''});
+        };
+
+        this.fixIndex = function (scope, settings, modelValue) {
+            if (settings.applyFilter && angular.isArray(modelValue) && modelValue.length > 0) {
+                var dragModelValueFiltered = scope[settings.applyFilter](),
+                    lookup = dragModelValueFiltered[settings.index],
+                    actualIndex = undefined;
+
+                modelValue.forEach(function (item, i) {
+                    if (angular.equals(item, lookup)) {
+                        actualIndex = i;
+                    }
+                });
+
+                return actualIndex;
+            }
+
+            return settings.index;
+        };
+    }]).directive('jqyouiDraggable', ['ngDragDropService', function (ngDragDropService) {
+        return {
+            require: '?jqyouiDroppable',
+            restrict: 'A',
+            link: function (scope, element, attrs) {
+                var dragSettings, jqyouiOptions, zIndex;
+                var updateDraggable = function (newValue, oldValue) {
+                    if (newValue) {
+                        dragSettings = scope.$eval(element.attr('jqyoui-draggable') || element.attr('data-jqyoui-draggable')) || {};
+                        jqyouiOptions = scope.$eval(attrs.jqyouiOptions) || {};
+                        element
+                            .draggable({disabled: false})
+                            .draggable(jqyouiOptions)
+                            .draggable({
+                                start: function (event, ui) {
+                                    zIndex = angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index');
+                                    angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index', 9999);
+                                    jqyoui.startXY = angular.element(this)[dragSettings.containment || 'offset']();
+                                    ngDragDropService.callEventCallback(scope, dragSettings.onStart, event, ui);
+                                },
+                                stop: function (event, ui) {
+                                    angular.element(jqyouiOptions.helper ? ui.helper : this).css('z-index', zIndex);
+                                    ngDragDropService.callEventCallback(scope, dragSettings.onStop, event, ui);
+                                },
+                                drag: function (event, ui) {
+                                    ngDragDropService.callEventCallback(scope, dragSettings.onDrag, event, ui);
+                                }
+                            });
+                    } else {
+                        element.draggable({disabled: true});
+                    }
+                };
+                scope.$watch(function () {
+                    return scope.$eval(attrs.drag);
+                }, updateDraggable);
+                updateDraggable();
+
+                element.on('$destroy', function () {
+                    element.draggable('destroy');
+                });
+            }
+        };
+    }]).directive('jqyouiDroppable', ['ngDragDropService', function (ngDragDropService) {
+        return {
+            restrict: 'A',
+            priority: 1,
+            link: function (scope, element, attrs) {
+                var dropSettings;
+                var updateDroppable = function (newValue, oldValue) {
+                    if (newValue) {
+                        dropSettings = scope.$eval(angular.element(element).attr('jqyoui-droppable') || angular.element(element).attr('data-jqyoui-droppable')) || {};
+                        element
+                            .droppable({disabled: false})
+                            .droppable(scope.$eval(attrs.jqyouiOptions) || {})
+                            .droppable({
+                                over: function (event, ui) {
+                                    ngDragDropService.callEventCallback(scope, dropSettings.onOver, event, ui);
+                                },
+                                out: function (event, ui) {
+                                    ngDragDropService.callEventCallback(scope, dropSettings.onOut, event, ui);
+                                },
+                                drop: function (event, ui) {
+                                    if (angular.element(ui.draggable).ngattr('ng-model') && attrs.ngModel) {
+                                        ngDragDropService.invokeDrop(angular.element(ui.draggable), angular.element(this), event, ui);
+                                    } else {
+                                        ngDragDropService.callEventCallback(scope, dropSettings.onDrop, event, ui);
+                                    }
+                                }
+                            });
+                    } else {
+                        element.droppable({disabled: true});
+                    }
+                };
+
+                scope.$watch(function () {
+                    return scope.$eval(attrs.drop);
+                }, updateDroppable);
+                updateDroppable();
+
+                element.on('$destroy', function () {
+                    element.droppable('destroy');
+                });
+            }
+        };
+    }]);
+
+    $.fn.ngattr = function (name, value) {
+        var element = angular.element(this).get(0);
+
+        return element.getAttribute(name) || element.getAttribute('data-' + name);
     };
-  }]);
-
-  $.fn.ngattr = function(name, value) {
-    var element = angular.element(this).get(0);
-
-    return element.getAttribute(name) || element.getAttribute('data-' + name);
-  };
 })(window, window.angular);


### PR DESCRIPTION
This commit is inspired from Pete Clodi's work. Fixed the animations and added a new attribute sortable. If it is sortable, you can drag and drop - this would make the elements slide left/or right based on the shift. I added a new demo file  dnd-ctrls-sortables to see this in action. 