### PR TITLE
Fixing copy-paste error on droppable disabled flag name

### DIFF
--- a/partials/overview.html
+++ b/partials/overview.html
@@ -199,7 +199,7 @@ App.controller('OverviewCtrl', function($scope) {
        <td>requires if both droppable as well as draggable share the same ngModel.</td>
      </tr>
      <tr>
-       <td>data-drag</td>
+       <td>data-drop</td>
        <td>boolean</td>
        <td>true</td>
        <td>If true, element can be droppable. Disabled otherwise.</td>


### PR DESCRIPTION
Droppable disabled flag name is actually "drop", not "drag".
