### PR TITLE
Update bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -16,13 +16,11 @@
     "package.json"
   ],
   "dependencies": {
-    
+    "jquery-ui": "latest",
+    "angular": "~1.x"
   },
   "devDependencies": {
     "angular-mocks": "~1.x",
-    "angular": "~1.x",
-    "jquery": "2.x",
-    "jquery-ui": "latest",
     "angular-ui-bootstrap-bower": "~0.12.0"
   }
 }


### PR DESCRIPTION
Context: #145
angular and jquery ui are required dependencies but bootstrap is only needed for the demo. jqueryui already depends on jquery.