### PR TITLE
Fixing the droppable settings to allow changing tolerance

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -335,7 +335,8 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
                   }), function() {
                     ui.draggable.css({left: '', top: ''});
                   });
-                }
+                },
+                tolerance: dropSettings.tolerance || 'intersect'
               });
           } else {
             element.droppable({disabled: true});


### PR DESCRIPTION
Changed line 339 to allow the tolerance parameter from the jquery ui droppable element, so it can be changed from 'intersect' to any of the 4 options availavble. If not provided, uses default 'intersect' tolerance.