### PR TITLE
added Meteor package.js Package info

### DIFF
--- a/.versions
+++ b/.versions
@@ -1,0 +1,7 @@
+angular:angular@1.4.2
+heinerion:angular-dragdrop@1.0.11
+jquery@1.11.3_2
+meteor@1.1.6
+mizzao:build-fetcher@0.2.0
+mizzao:jquery-ui@1.11.4
+underscore@1.0.3

--- a/README.md
+++ b/README.md
@@ -1,16 +1,16 @@
-#Drag and Drop for AngularJS (with Animation) [![Build Status](https://api.travis-ci.org/codef0rmer/angular-dragdrop.svg?branch=master)](https://travis-ci.org/codef0rmer/angular-dragdrop)
- 
+# Drag and Drop for AngularJS (with Animation) [![Build Status](https://api.travis-ci.org/codef0rmer/angular-dragdrop.svg?branch=master)](https://travis-ci.org/codef0rmer/angular-dragdrop)
+
 ---
 
 Implementing jQueryUI Drag and Drop functionality in AngularJS is easier than ever which is a wrapper for jQueryUI draggable/droppable components.
 
 
-###v1.0.9 - breaking change
+### v1.0.9 - breaking change
   1. Draggable and Droppable will not be [deep copied](https://egghead.io/lessons/angularjs-angular-copy-for-deep-copy) by default unlike previous versions. Use `deepCopy` option if prototypical inheritance is not required.
   2. Callbacks will not be executed forcefully within the context of scope which requires an extra digest loop for each event (start, stop, over, out, etc), especially drag that fires many times and running a digest loop is performance intensive in such scenario. Call `scope.$apply()` within callback, if needed.
 
 
-##How to Use
+## How to Use
 
  * `bower install angular-dragdrop` (or `sudo bower install angular-dragdrop --allow-root`)
  * Reference `angular-dragdrop.min.js` in your application as:
@@ -31,7 +31,7 @@ angular.module('myApp', ['ngDragDrop'])
  ```
  * Finally, check out [the cool demos](http://codef0rmer.github.io/angular-dragdrop/#/)
 
-##Angular Draggable options
+## Angular Draggable options
 * **jqyoui-draggable** – A custom angular attribute to make any element draggable. It holds more settings such as:
     * **index** – number – $index of an item of a model (if it is an array) associated with it
     * **placeholder** – boolean/string – If true, the place will be occupied even though a dragggable is moved/dropped somewhere else. If 'keep' is supplied, the original item won't be removed from the draggable.
@@ -40,14 +40,14 @@ angular.module('myApp', ['ngDragDrop'])
     * **onStop** – string – callback method to be invoked when dragging stops
     * **onDrag** – string – callback method to be invoked while the mouse is moved during the dragging
     * **applyFilter** - string - applies AngularJS $filter on the list before swapping items. Only applicable, if ngRepeat has any filter (such as orderBy, limitTo) associated with it.
-    * **containment** – string - position/offset. Offset by default. This forces to use jQuery.position() or jQuery.offset() to calculate proper position with respect to parent element or document respectively. 
+    * **containment** – string - position/offset. Offset by default. This forces to use jQuery.position() or jQuery.offset() to calculate proper position with respect to parent element or document respectively.
     * **deepCopy** - boolean (optional) – If true, makes a deep copy of draggable that looses prototypical inheritance.
-    * **beforeDrop** – promise (optional) – Ask for confirmation before swapping. Works with both window.confirm and custom popup. 
+    * **beforeDrop** – promise (optional) – Ask for confirmation before swapping. Works with both window.confirm and custom popup.
 * **data-drag** – boolean – If true, element can be draggable. Disabled otherwise.
 * **data-jqyoui-options** – object – should hold all the valid options supported by [jQueryUI Draggable](http://api.jqueryui.com/draggable)
 * **ng-model** – string – An angular model defined in a controller. Should be a JS array or object
 
-##Angular Droppable options
+## Angular Droppable options
 * **jqyoui-droppable** – A custom angular attribute to make any element droppable. It holds more settings such as:
     * **index** – number – $index of an item of a model (if it is an array) associated with it
     * **multiple** – boolean – Requires to be true only if animate is set to true for draggable and to avoid swapping.
@@ -56,14 +56,14 @@ angular.module('myApp', ['ngDragDrop'])
     * **onOver** – string – callback method to be invoked when an accepted draggable is dragged over the droppable
     * **onOut** – string – callback method to be invoked when an accepted draggable is dragged out of the droppable
     * **applyFilter** - string - requires if both droppable as well as draggable share the same ngModel.
-    * **containment** – string - position/offset. Offset by default. This forces to use jQuery.position() or jQuery.offset() to calculate proper position with respect to parent element or document respectively. 
+    * **containment** – string - position/offset. Offset by default. This forces to use jQuery.position() or jQuery.offset() to calculate proper position with respect to parent element or document respectively.
     * **deepCopy** – boolean (optional) – If true, makes a deep copy of droppable that looses prototypical inheritance.
-    * **beforeDrop** – promise (optional) – Ask for confirmation before dropping. Works with both window.confirm and custom popup. 
+    * **beforeDrop** – promise (optional) – Ask for confirmation before dropping. Works with both window.confirm and custom popup.
 * **data-drop** – boolean – If true, element can be droppable. Disabled otherwise.
 * **data-jqyoui-options** – object – should hold all the valid options supported by [jQueryUI Droppable](http://api.jqueryui.com/droppable)
 * **ng-model** – string – An angular model defined in a controller. Should be a JS array or object.
 
-##How to Contribute
+## How to Contribute
 * $ git clone https://github.com/codef0rmer/angular-dragdrop.git
 * $ cd angular-dragdrop
 * $ npm install --quiet -g karma-cli bower
@@ -71,17 +71,17 @@ angular.module('myApp', ['ngDragDrop'])
 * $ sudo bower install --force-latest
 * $ npm test
 
-##Demo
+## Demo
 Demo is [here](http://codef0rmer.github.io/angular-dragdrop/#/)
 
 
-###v1.0.5 - breaking change
-Do not pass evaluated expressions in callbacks. For example, 
-####Before:
+### v1.0.5 - breaking change
+Do not pass evaluated expressions in callbacks. For example,
+#### Before:
 ```
 <div jqyoui-draggable="{onStart:'startCallback({{item}})'}">{{item.title}}</div>
 ```
-####After:
+#### After:
 ```
 <div jqyoui-draggable="{onStart:'startCallback(item)'}">{{item.title}}</div>
 ```

--- a/package.js
+++ b/package.js
@@ -1,0 +1,28 @@
+// package metadata file for Meteor.js
+var packageName = 'heinerion:angular-dragdrop';
+var where = 'client'; // where to install: 'client' or 'server'. For both, pass nothing.
+var version = '1.0.11';
+var summary = "This directive allows you to use jQuery UI's draggable and droppable plugins with AngularJS.";
+var gitLink = 'https://github.com/codef0rmer/angular-dragdrop';
+var documentationFile = 'README.md';
+
+// Meta-data
+Package.describe({
+  name: packageName,
+  version: version,
+  summary: summary,
+  git: gitLink,
+  documentation: documentationFile
+});
+
+Package.onUse(function(api) {
+  api.versionsFrom(['METEOR@0.9.0', 'METEOR@1.0']); // Meteor versions
+
+  api.use([
+    'angular:angular@1.4.2',
+    'mizzao:jquery-ui@1.11.4'
+  ], where);
+
+  // Meteor minifies for you!
+  api.addFiles('src/angular-dragdrop.js', where); // Files in use
+});


### PR DESCRIPTION
Hello,
I needed your repo for my meteor project and no package was on atmospherejs.com.

So, according to http://angular-meteor.com/tutorials/angular1/3rd-party-libraries, I simply wrote the missing package.js File and published it.

The downside with atmosphere is, that I needed to have an account to bind the package to it.
So I created an account, using my name, and added the package to that.
Therefore the current project location/name is "heinerion:angular-dragdrop" as seen in the package.js.
To publish the project under your name (so it would be codef0rmer:angular-dragdrop) you would simply have to create an account on meteor.com and change the package.js accordingly.

I hope, I wasn't too eager.

I Also needed to change the README.md, adding Spaces between the #'s and the Headlines, so that Meteor can parse it.

With kind regards,
Heinerion