### PR TITLE
Added support for 'controllerAs' syntax in event callbacks

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -43,23 +43,26 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
           callback = objExtract.callback,
           constructor = objExtract.constructor,
           args = [event, ui].concat(objExtract.args);
-      
+
       // call either $scoped method i.e. $scope.dropCallback or constructor's method i.e. this.dropCallback.
       // Removing scope.$apply call that was performance intensive (especially onDrag) and does not require it
       // always. So call it within the callback if needed.
-      return (scope[callback] || scope[constructor][callback]).apply(scope, args);
-      
+      return (scope[constructor] && scope[constructor][callback]
+              ? scope[constructor][callback]
+              : scope[callback]
+        ).apply([scope[constructor] || scope], args);
+
       function extract(callbackName) {
         var atStartBracket = callbackName.indexOf('(') !== -1 ? callbackName.indexOf('(') : callbackName.length,
             atEndBracket = callbackName.lastIndexOf(')') !== -1 ? callbackName.lastIndexOf(')') : callbackName.length,
             args = callbackName.substring(atStartBracket + 1, atEndBracket), // matching function arguments inside brackets
             constructor = callbackName.indexOf('.') !== -1 ? callbackName.substr(0, callbackName.indexOf('.')) : null; // matching a string upto a dot to check ctrl as syntax
-            constructor = scope[constructor] && typeof scope[constructor].constructor === 'function' ? constructor : null;
+            //constructor = scope[constructor] && typeof scope[constructor].constructor === 'function' ? constructor : null;
 
         return {
           callback: callbackName.substring(constructor && constructor.length + 1 || 0, atStartBracket),
           args: $.map(args && args.split(',') || [], function(item) { return [$parse(item)(scope)]; }),
-          constructor: constructor
+          constructor: scope[constructor] && typeof scope[constructor].constructor === 'function' ? constructor : null
         }
       }
     };

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -50,7 +50,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
       return (scope[constructor] && scope[constructor][callback]
               ? scope[constructor][callback]
               : scope[callback]
-        ).apply([scope[constructor] || scope], args);
+        ).apply((scope[constructor] || scope), args);
 
       function extract(callbackName) {
         var atStartBracket = callbackName.indexOf('(') !== -1 ? callbackName.indexOf('(') : callbackName.length,
@@ -197,7 +197,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
             toPos.top+= $toEl.outerHeight(true);
           }
         } else {
-          // Angular v1.2 uses ng-hide to hide an element 
+          // Angular v1.2 uses ng-hide to hide an element
           // so we've to remove it in order to grab its position
           if (hadNgHideCls) $toEl.removeClass('ng-hide');
           toPos = $toEl.css({'visibility': 'hidden', 'display': 'block'})[dropSettings.containment || 'offset']();
@@ -402,7 +402,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
         killWatcher = scope.$watch(function() { return scope.$eval(attrs.drop); }, updateDroppable);
         updateDroppable();
-        
+
         element.on('$destroy', function() {
           element.droppable({disabled: true}).droppable('destroy');
         });

--- a/test/spec/tests.js
+++ b/test/spec/tests.js
@@ -200,4 +200,47 @@ describe('Service: ngDragDropService', function() {
     timeout.flush();
     expect(scope.list.map(function(item) { return item.title; }).join('')).toBe('NNLIIE');
   });
+
+  describe("controller as support", function() {
+    var Controller;
+    beforeEach(function() {
+      Controller = (function(){
+        var ctrl = function(){
+          this.list = [
+            { 'title': 'N' },
+            { 'title': 'L' },
+            { 'title': 'I' },
+            { 'title': 'I' },
+            { 'title': 'E' },
+            { 'title': 'N' }
+          ];
+        };
+        ctrl.prototype.onDrop = function() {
+          return "ctrl";
+        };
+        return ctrl;
+      })();
+      scope.vm = new Controller();
+      scope.onDrop = function() {
+        return "scope";
+      }
+    });
+
+    it('should use controller method when prefixed with constructor', function() {
+      var callbackResult = ngDragDropService.callEventCallback(scope, "vm.onDrop");
+      expect(callbackResult).toEqual("ctrl");
+    });
+
+    it('should use scope method when not prefixed with constructor', function() {
+      var callbackResult = ngDragDropService.callEventCallback(scope, "onDrop");
+      expect(callbackResult).toEqual("scope");
+    });
+
+    it('should use scope method when prefix does not exist on scope', function() {
+      var callbackResult = ngDragDropService.callEventCallback(scope, "this.onDrop");
+      expect(callbackResult).toEqual("scope");
+      callbackResult = ngDragDropService.callEventCallback(scope, "self.onDrop");
+      expect(callbackResult).toEqual("scope");
+    })
+  });
 });

--- a/test/spec/tests.js
+++ b/test/spec/tests.js
@@ -205,15 +205,18 @@ describe('Service: ngDragDropService', function() {
     var Controller;
     beforeEach(function() {
       Controller = (function(){
-        var ctrl = function(){};
+        var ctrl = function(){
+          this.message = "ctrl";
+        };
         ctrl.prototype.onDrop = function() {
-          return "ctrl";
+          return this.message;
         };
         return ctrl;
       })();
       scope.vm = new Controller();
+      scope.message = "scope";
       scope.onDrop = function() {
-        return "scope";
+        return this.message;
       }
     });
 

--- a/test/spec/tests.js
+++ b/test/spec/tests.js
@@ -171,7 +171,7 @@ describe('Service: ngDragDropService', function() {
     scope.filterIt = function() {
       return orderByFilter(scope.list, 'title');
     };
-    
+
     expect(ngDragDropService.fixIndex(scope, {index: 1, applyFilter: 'filterIt'}, scope.list)).toBe(0);
     expect(ngDragDropService.fixIndex(scope, {index: 0, applyFilter: 'filterIt'}, scope.list)).toBe(1);
 
@@ -205,16 +205,7 @@ describe('Service: ngDragDropService', function() {
     var Controller;
     beforeEach(function() {
       Controller = (function(){
-        var ctrl = function(){
-          this.list = [
-            { 'title': 'N' },
-            { 'title': 'L' },
-            { 'title': 'I' },
-            { 'title': 'I' },
-            { 'title': 'E' },
-            { 'title': 'N' }
-          ];
-        };
+        var ctrl = function(){};
         ctrl.prototype.onDrop = function() {
           return "ctrl";
         };


### PR DESCRIPTION
Added support for using `controllerAs` syntax when defining event callbacks such as `onDrop`. 

Instead of always setting the scope as context to the callback, it now sets the constructor to the context is the constructor exists on the scope. Uses of `this` in the callback should therefore refer to the controller.