### PR TITLE
feat(*): Animate when beforeDrop results in rejection

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -383,7 +383,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
                       ngDragDropService.callEventCallback(scope, dropSettings.onDrop, event, ui);
                     }
                   }), function() {
-                    ui.draggable.css({left: '', top: ''});
+                    ui.draggable.animate({left: '', top: ''});
                   });
                 }
               });


### PR DESCRIPTION
@codef0rmer Changing line 276 had no effect on what happens when 'beforeDrop' is rejected so I moved the proposed change to line 386. However, shouldn't `this.restore($draggable)` be called here instead? Then `animate()` would in fact need to be called from line 276.

In addition, I'm not sure if we should be checking for `animate:true` or the value of `revert` before deciding to do `animate`. Let me know what you think. 