### PR TITLE
Protocol relative URLs because file loading is blocked

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,9 +9,9 @@
     <meta name="author" content="">
 
     <!-- Le styles - Please update my github page for god sake... -->
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap.min.css" rel="stylesheet">
-    <link href="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap-responsive.min.css" rel="stylesheet">
-    <link href="http://twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap.min.css" rel="stylesheet">
+    <link href="//netdna.bootstrapcdn.com/twitter-bootstrap/2.1.1/css/bootstrap-responsive.min.css" rel="stylesheet">
+    <link href="//twitter.github.com/bootstrap/assets/js/google-code-prettify/prettify.css" rel="stylesheet">
     <link src="assets/prettify.css">
     <style type="text/css">
       body {
@@ -59,11 +59,11 @@
     <!-- Le javascript
     ================================================== -->
     <!-- Placed at the end of the document so the pages load faster -->
-    <script src="http://ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
-    <script src="http://ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"></script>
-    <script src="http://netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
-    <script src="http://code.angularjs.org/snapshot/angular.min.js"></script>
-    <script src="http://code.angularjs.org/snapshot/angular-route.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jquery/1.9.0/jquery.min.js"></script>
+    <script src="//ajax.googleapis.com/ajax/libs/jqueryui/1/jquery-ui.min.js"></script>
+    <script src="//netdna.bootstrapcdn.com/twitter-bootstrap/2.3.2/js/bootstrap.min.js"></script>
+    <script src="//code.angularjs.org/snapshot/angular.min.js"></script>
+    <script src="//code.angularjs.org/snapshot/angular-route.min.js"></script>
     <script src="angular-dragdrop.min.js" type='text/javascript'></script>
     <script src="assets/prettify.js"></script>
     <script> 


### PR DESCRIPTION
Added [Protocol relative URLs](www.paulirish.com/2010/the-protocol-relative-url/)

None of the assets from CDNs was being loaded on both Chrome and Firefox, so demos just looked like static content.