### PR TITLE
Drop items are not necessarily deep copied

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 components
 todo.TODO
+/*.sublime-*

--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -122,7 +122,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
           if (dragSettings.index > dropSettings.index) {
             temp = dragModelValue[dragSettings.index];
             for (var i = dragSettings.index; i > dropSettings.index; i--) {
-              dropModelValue[i] = angular.copy(dropModelValue[i - 1]);
+              dropModelValue[i] = dragSettings.deepCopy ? angular.copy(dropModelValue[i - 1]) : dropModelValue[i - 1];
               dropModelValue[i - 1] = {};
               dropModelValue[i][dragSettings.direction] = 'left';
             }
@@ -130,7 +130,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
           } else {
             temp = dragModelValue[dragSettings.index];
             for (var i = dragSettings.index; i < dropSettings.index; i++) {
-              dropModelValue[i] = angular.copy(dropModelValue[i + 1]);
+              dropModelValue[i] = dragSettings.deepCopy ? angular.copy(dropModelValue[i + 1]) : dropModelValue[i + 1];
               dropModelValue[i + 1] = {};
               dropModelValue[i][dragSettings.direction] = 'right';
             }


### PR DESCRIPTION
https://github.com/codef0rmer/angular-dragdrop/issues/143 had been closed, but items still were deep copied even when settings were specifying not to do so.