### PR TITLE
Fix readme to correct rendering problem in npmjs

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,20 +19,20 @@ Implementing jQueryUI Drag and Drop functionality in AngularJS is easier than ev
  * `bower install angular-dragdrop` (or `sudo bower install angular-dragdrop --allow-root`)
  * Reference `angular-dragdrop.min.js` in your application as:
 
-   ```
-<script src="components/angular-dragdrop/src/angular-dragdrop.min.js"></script>
-```
+  ```
+  <script src="components/angular-dragdrop/src/angular-dragdrop.min.js"></script>
+  ```
  * Resolve the dependency in the main module of your application as:
 
- ```
- angular.module('myApp', ['ngDragDrop'])
- ```
+  ```
+  angular.module('myApp', ['ngDragDrop'])
+  ```
 
  * Drag anything as:
 
- ```
- <span data-drag="true" jqyoui-draggable>So you think you can drag</span>
- ```
+  ```
+  <span data-drag="true" jqyoui-draggable>So you think you can drag</span>
+  ```
  * Finally, check out [the cool demos](http://codef0rmer.github.io/angular-dragdrop/#/)
  * Note, use [touchpunch.js](http://touchpunch.furf.com/) to enable drag/drop on touch devices.
 


### PR DESCRIPTION
The same readme file is used in npmjs to provide a description.
In npmjs, readme is rendered wrong because of errors in markdown
formatting.

Addresses issue #303 