### PR TITLE
$destroy event is not triggered when angular view is destroyed becaus…

### DIFF
--- a/src/angular-dragdrop.js
+++ b/src/angular-dragdrop.js
@@ -340,7 +340,7 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
         killWatcher = scope.$watch(function() { return scope.$eval(attrs.drag); }, updateDraggable);
         updateDraggable();
 
-        element.on('$destroy', function() {
+        elem.on('$destroy', function() {
           element.draggable({disabled: true}).draggable('destroy');
         });
       }
@@ -403,8 +403,8 @@ var jqyoui = angular.module('ngDragDrop', []).service('ngDragDropService', ['$ti
 
         killWatcher = scope.$watch(function() { return scope.$eval(attrs.drop); }, updateDroppable);
         updateDroppable();
-        
-        element.on('$destroy', function() {
+
+        elem.on('$destroy', function() {
           element.droppable({disabled: true}).droppable('destroy');
         });
       }


### PR DESCRIPTION
$destroy event is not triggered when angular view is destroyed because “element” is jQuery object.
So, it cause memory leak.
Changed to listen $destroy event on “elem” that is angular element
Then, $destroy event is triggered when angular view is destroyed.